### PR TITLE
feat: move keyboard done button to right

### DIFF
--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/TextInput/TextInputViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/TextInput/TextInputViewController.swift
@@ -127,7 +127,8 @@ public final class TextInputViewController<InputType>: UIViewController, UITextF
     func barButton(_ keyboardDoneButton: String) {
         let bar = UIToolbar()
         let done = UIBarButtonItem(title: NSLocalizedString(key: keyboardDoneButton), style: .done, target: self, action: #selector(dismissKeyboard))
-        bar.items = [done]
+        let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        bar.items = [space, done]
         bar.sizeToFit()
         textField.inputAccessoryView = bar
     }


### PR DESCRIPTION
# GOVAPP-58: Keyboard done button to right

Moving the done button above the keyboard on the text input screen from left to right.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
