### PR TITLE
chore: changed border edge from array to set

### DIFF
--- a/Sources/GDSCommon/Extensions/UIKit/UIView+BorderExtension.swift
+++ b/Sources/GDSCommon/Extensions/UIKit/UIView+BorderExtension.swift
@@ -8,15 +8,15 @@ public enum BorderEdge: CaseIterable {
 }
 
 extension Collection where Element == BorderEdge {
-    static var all: [BorderEdge] {
-        BorderEdge.allCases
+    static var all: Set<BorderEdge> {
+        Set(BorderEdge.allCases)
     }
     
-    static var vertical: [BorderEdge] {
+    static var vertical: Set<BorderEdge> {
         [.right, .left]
     }
     
-    static var horizontal: [BorderEdge] {
+    static var horizontal: Set<BorderEdge> {
         [.top, .bottom]
     }
 }
@@ -28,7 +28,7 @@ extension UIView {
                        width: 0.25)
     }
     
-    public func bordersTo(_ edges: [BorderEdge],
+    public func bordersTo(_ edges: Set<BorderEdge>,
                           colour: UIColor = .label,
                           width: Double = 1) {
         

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Components/DatePickerViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Components/DatePickerViewModel.swift
@@ -17,7 +17,7 @@ public protocol DatePickerViewModel {
 
 @available(iOS 13.4, *)
 extension DatePickerViewModel {
-    var pickerStyle: UIDatePickerStyle {
+    public var pickerStyle: UIDatePickerStyle {
         if #available(iOS 14, *) {
             return UIDatePickerStyle.inline
         } else {
@@ -25,7 +25,7 @@ extension DatePickerViewModel {
         }
     }
     
-    mutating func setSelectedDate(_ date: Date) {
+    public mutating func setSelectedDate(_ date: Date) {
         self.selectedDate = date
     }
 }


### PR DESCRIPTION
# GOVAPP-59: Changed border edge from array to set

This is to prevent multiple borders being drawn that overlap each other if developer / consumers of this were to for example pass in to the method:

`[.top, .top, .bottom, .bottom, .bottom]`

By the parameter now being a set, each member has to be unique so the resulting collection will only contain a single item of each edge.

Also changed `UIDatePickerStyle` property to be public to be accessible outside package.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
