### PR TITLE
fix: quailty-report.yml uses Demo scheme

### DIFF
--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -21,8 +21,9 @@ jobs:
           
       - name: Build and Test
         run: |
-          xcodebuild -scheme GDSCommon-Package test -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
-            -enableCodeCoverage YES -resultBundlePath result.xcresult
+          xcodebuild -workspace "GDSCommon-Demo.xcworkspace" -scheme GDSCommon-Demo test \
+           -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
+           -enableCodeCoverage YES -resultBundlePath result.xcresult
             
       - name: Run SonarCloud Scanning
         run: |


### PR DESCRIPTION
# DCMAW-7090: update quality-report.yml to use correct scheme

Updated the .yml to use the correct scheme previously this workflow was using the package scheme, when a demo project was introduced with a new scheme to help test UIViewControllers the PR workflow was updated but this one was left out this PR will fix that.

# Checklist

## Before raising your pull request:
- [ ] ~Ran the app locally ensuring it builds~
- [ ] ~Ran the tests locally ensuring they pass on Build~
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] ~Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
- [ ] ~Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
- [ ] ~Ran the app and tested the feature on a range of device sizes~
      ~Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.~
- [ ] ~Written Unit and Integration tests if needed~

- [ ] ~Met all accessibility requirements?~
    - [ ] ~Checked dynamic type sizes are applied~
    - [ ] ~Checked VoiceOver can navigate your new code~
    - [ ] ~Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
