### PR TITLE
feat: added optional right bar button item to Instructions Screen Pattern

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Extensions/ViewControllerInitialiser+Extensions.swift
@@ -32,3 +32,10 @@ extension TextInputViewController<Double> {
         self.init(viewModel: viewModel)
     }
 }
+
+extension GDSInstructionsViewController {
+    convenience init() {
+        let viewModel = MockGDSInstructionsViewModel(buttonViewModel: MockButtonViewModel(title: "Button title", action: {}))
+        self.init(viewModel: viewModel)
+    }
+}

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockGDSInstructionsViewModel.swift
@@ -4,10 +4,12 @@ import UIKit
 class MockGDSInstructionsViewModel: GDSInstructionsViewModel {
     var title: GDSLocalisedString
     var body: String
+    var rightBarButtonTitle: GDSLocalisedString? = "right bar button"
     var childView: UIView
     var buttonViewModel: ButtonViewModel
     var secondaryButtonViewModel: ButtonViewModel?
     func didAppear() {}
+    func didDismiss() {}
     
     init(title: GDSLocalisedString = "This is the Instructions View",
          body: String = "We can add a subtitle here to give some extra context",

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -36,8 +36,7 @@ enum Screens: String, CaseIterable {
     var view: UIViewController {
         switch self {
         case .gdsInstructions:
-            let viewModel = MockGDSInstructionsViewModel(buttonViewModel: mockButtonViewModel)
-            return GDSInstructionsViewController(viewModel: viewModel)
+            return GDSInstructionsViewController()
         case .gdsInstructionsWithImage:
             let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: mockButtonViewModel,
                                                                primaryButtonViewModel: mockButtonViewModel,

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
@@ -10,6 +10,7 @@ final class GDSInstructionsViewControllerTests: XCTestCase {
     
     var screenDidAppear = false
     var didTapButton = false
+    var didDismiss = false
     
     override func setUp() {
         super.setUp()
@@ -26,6 +27,8 @@ final class GDSInstructionsViewControllerTests: XCTestCase {
         viewModel = MockGDSInstructionsViewModel(childView: bulletView,
                                                  buttonViewModel: buttonViewModel, secondaryButtonViewModel: buttonViewModel) {
             self.screenDidAppear = true
+        } dismissAction: {
+            self.didDismiss = true
         }
         
         sut = GDSInstructionsViewController(viewModel: viewModel)
@@ -60,6 +63,21 @@ extension GDSInstructionsViewControllerTests {
         
         XCTAssertEqual(try sut.bodyLabel.text, "test body"
         )
+    }
+    
+    func testTitleBar() {
+        XCTAssertEqual(sut.navigationItem.hidesBackButton, false)
+        sut.navigationItem.hidesBackButton = true
+        XCTAssertEqual(sut.navigationItem.hidesBackButton, true)
+        
+        sut.beginAppearanceTransition(true, animated: false)
+        XCTAssertNotNil(sut.navigationItem.rightBarButtonItem)
+        XCTAssertEqual(sut.navigationItem.rightBarButtonItem?.title, "right bar button")
+
+        XCTAssertFalse(didDismiss)
+
+        _ = sut.navigationItem.rightBarButtonItem?.target?.perform(sut.navigationItem.rightBarButtonItem?.action)
+        XCTAssertTrue(didDismiss)
     }
     
     func test_bullets() throws {

--- a/GDSCommon-Demo/GDSCommon-DemoTests/MockGDSInstructionsViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/MockGDSInstructionsViewModel.swift
@@ -4,13 +4,19 @@ import UIKit
 internal struct MockGDSInstructionsViewModel: GDSInstructionsViewModel {
     let title: GDSLocalisedString = "test title"
     let body: String = "test body"
+    let rightBarButtonTitle: GDSLocalisedString? = "right bar button"
     let childView: UIView
     let buttonViewModel: ButtonViewModel
     let secondaryButtonViewModel: ButtonViewModel?
     
     let screenView: () -> Void
+    let dismissAction: () -> Void
     
     func didAppear() {
         screenView()
+    }
+    
+    func didDismiss() {
+        dismissAction()
     }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewController.swift
@@ -41,6 +41,13 @@ public class GDSInstructionsViewController: UIViewController {
         primaryButton.isEnabled = true
         primaryButton.isLoading = false
         setBackButtonTitle()
+        
+        if viewModel.rightBarButtonTitle != nil {
+            self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle?.value,
+                                                           style: .done,
+                                                           target: self,
+                                                           action: #selector(dismissScreen))
+        }
     }
     
     public override func viewDidAppear(_ animated: Bool) {
@@ -108,5 +115,11 @@ public class GDSInstructionsViewController: UIViewController {
         if let buttonViewModel = viewModel.secondaryButtonViewModel {
             buttonViewModel.action()
         }
+    }
+    
+    @objc private func dismissScreen() {
+        self.dismiss(animated: true)
+        
+        viewModel.didDismiss()
     }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewModel.swift
@@ -3,6 +3,7 @@ import UIKit
 /// View model for the ``GDSInstructionsViewController``
 /// - `title` type is ``GDSLocalisedString``
 /// - `body` type is `NSAttributedString`
+/// - `rightBarButtonTitle` type is ``GDSLocalisedString``?
 /// - `childView type is `UIView`
 /// - `primaryButtonViewModel` type is ``ButtonViewModel``
 /// - `secondaryButtonViewModel` type is ``ButtonViewModel``?
@@ -14,12 +15,16 @@ import UIKit
 /// for any code that needs to be performed when the screen appears.
 /// For example, this might include tracking an analytics screen view, but it could be used
 /// for other code such as making an API call.
+/// If `rightBarButtonTitle` is `nil` then the navigation item right bar button is hidden
+/// Otherwise, it is set to the title property and the action is set to the `didDismiss()` action.
 public protocol GDSInstructionsViewModel {
     var title: GDSLocalisedString { get }
     var body: String { get }
+    var rightBarButtonTitle: GDSLocalisedString? { get }
     var childView: UIView { get }
     var buttonViewModel: ButtonViewModel { get }
     var secondaryButtonViewModel: ButtonViewModel? { get }
     
     func didAppear()
+    func didDismiss()
 }


### PR DESCRIPTION
# Added right bar button property to `GDSInstructions` view model and screen

This brings the screen in line with other recently added screens and allows the ability to dismiss the screen.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
