### PR TITLE
feat!: adding-optional-parameters-for-image-instructions

### DIFF
--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockButtonViewModel.swift
@@ -3,18 +3,28 @@ import GDSCommon
 
 class MockButtonViewModel: ButtonViewModel {
     var title: GDSLocalisedString
-    var icon: String?
+    var icon: ButtonIconViewModel?
     var shouldLoadOnTap: Bool
     var action: () -> Void
     
     init(title: GDSLocalisedString,
-         icon: String? = nil,
+         icon: ButtonIconViewModel? = nil,
          shouldLoadOnTap: Bool = false,
          action: @escaping () -> Void) {
         self.title = title
         self.icon = icon
         self.shouldLoadOnTap = shouldLoadOnTap
         self.action = action
+    }
+}
+  
+class MockButtonIconViewModel: ButtonIconViewModel {
+    var iconName: String
+    var symbolPosition: SymbolPosition
+    
+    init(iconName: String, symbolPosition: SymbolPosition) {
+        self.iconName = iconName
+        self.symbolPosition = symbolPosition
     }
 }
   

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockInstructionWithImageViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockInstructionWithImageViewModel.swift
@@ -7,24 +7,38 @@ class MockInstructionsWithImageViewModel: InstructionsWithImageViewModel {
     var image: UIImage
     var warningButtonViewModel: ButtonViewModel?
     var primaryButtonViewModel: ButtonViewModel
-    
+    var secondaryButtonViewModel: ButtonViewModel?
+    var rightBarButtonTitle: GDSLocalisedString?
+
     let screenView: () -> Void
-    
+    let dismissAction: () -> Void
+
     func didAppear() {
         screenView()
     }
+    
+    func didDismiss() {
+        dismissAction()
+    }
+    
     
     init(title: GDSLocalisedString = "This is the Instructions with image view",
          body: NSAttributedString = NSAttributedString("We can use this body to provide details or context as to what we want the users to do"),
          image: UIImage = UIImage(named: "licence")!,
          warningButtonViewModel: ButtonViewModel? = nil,
          primaryButtonViewModel: ButtonViewModel,
-         screenView: @escaping () -> Void) {
+         secondaryButtonViewModel: ButtonViewModel? = nil,
+         rightBarButtonTitle: GDSLocalisedString? = nil,
+         screenView: @escaping () -> Void,
+         dismissAction: @escaping () -> Void) {
         self.title = title
         self.body = body
         self.image = image
         self.warningButtonViewModel = warningButtonViewModel
         self.primaryButtonViewModel = primaryButtonViewModel
+        self.secondaryButtonViewModel = secondaryButtonViewModel
+        self.rightBarButtonTitle = rightBarButtonTitle
         self.screenView = screenView
+        self.dismissAction = dismissAction
     }
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockOptionViewModel.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/MockOptionViewModel.swift
@@ -18,7 +18,7 @@ public struct MockOptionViewModel2: OptionViewModel {
 
 struct MockOptionButtonViewModel: ButtonViewModel {
     let title: GDSLocalisedString = "Example button text"
-    let icon: String? = nil
+    let icon: ButtonIconViewModel? = nil
     let shouldLoadOnTap: Bool = true
     let action: () -> Void = { }
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -85,8 +85,7 @@ enum Screens: String, CaseIterable {
             view.isModalInPresentation = true
             return view
         case .gdsListOptions:
-            let viewModel = MockListViewModel()
-            return ListOptionsViewController(viewModel: viewModel)
+            return ListOptionsViewController(viewModel: MockListViewModel())
         case .gdsIntroView:
             let viewModel = MockIntroViewModel(introButtonViewModel: mockButtonViewModel)
             return IntroViewController(viewModel: viewModel)
@@ -97,17 +96,11 @@ enum Screens: String, CaseIterable {
         case .gdsIconScreen:
             return IconScreenViewController()
         case .gdsQRCodeScanner:
-            let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) {
-                navigationController.popViewController(animated: true)
-            }
-            let vc = ScanningViewController(viewModel: viewModel)
-            return vc
+            let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) { navigationController.popViewController(animated: true) }
+            return ScanningViewController(viewModel: viewModel)
         case .gdsQRCodeScannerModal:
-            let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) {
-                navigationController.dismiss(animated: true)
-            }
-            let vc = ScanningViewController(viewModel: viewModel)
-            return vc
+            let viewModel = MockQRScanningViewModel(dialogPresenter: dialogPresenter) {  navigationController.dismiss(animated: true) }
+            return ScanningViewController(viewModel: viewModel)
         }
     }
 }

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -39,6 +39,14 @@ enum Screens: String, CaseIterable {
         MockButtonViewModel(title: "Action Button", shouldLoadOnTap: false, action: {})
     }
     
+    private var mockSecondaryButtonViewModel: ButtonViewModel {
+        MockButtonViewModel(title: "Secondary Button",
+                            icon: MockButtonIconViewModel(iconName: "qrcode",
+                                                          symbolPosition: .beforeTitle),
+                            shouldLoadOnTap: false,
+                            action: {})
+    }
+    
     private var dialogPresenter: DialogPresenter {
         DialogView<CheckmarkDialogAccessoryView>(title: "QR Scan Success",
                                                  isLoading: false)
@@ -47,7 +55,8 @@ enum Screens: String, CaseIterable {
     func create(in navigationController: UINavigationController) -> UIViewController {
         switch self {
         case .gdsInstructions:
-            let viewModel = MockGDSInstructionsViewModel(buttonViewModel: mockButtonViewModel)
+            let viewModel = MockGDSInstructionsViewModel(buttonViewModel: mockButtonViewModel,
+                                                         secondaryButtonViewModel: mockSecondaryButtonViewModel)
             return GDSInstructionsViewController(viewModel: viewModel)
         case .gdsInstructionsWithImage:
             let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: mockButtonViewModel,

--- a/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
+++ b/GDSCommon-Demo/GDSCommon-Demo/Mocks/Screens.swift
@@ -14,6 +14,7 @@ import UIKit
 enum Screens: String, CaseIterable {
     case gdsInstructions = "GDS Instructions View"
     case gdsInstructionsWithImage = "GDS Instructions View (with image)"
+    case gdsInstructionsWithImageModally = "GDS Instructions View (with image) - modal"
     case gdsModalInfoView = "Modal Info View"
     case gdsAttributedModalInfoView = "Attributed Modal Info View"
     case gdsListOptions = "List Options"
@@ -28,7 +29,8 @@ enum Screens: String, CaseIterable {
         switch self {
         case .gdsModalInfoView,
                 .gdsQRCodeScannerModal,
-                .gdsAttributedModalInfoView:
+                .gdsAttributedModalInfoView,
+                .gdsInstructionsWithImageModally:
             return true
         default:
             return false
@@ -61,7 +63,16 @@ enum Screens: String, CaseIterable {
         case .gdsInstructionsWithImage:
             let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: mockButtonViewModel,
                                                                primaryButtonViewModel: mockButtonViewModel,
-                                                               screenView: {})
+                                                               screenView: {},
+                                                               dismissAction: {})
+            return InstructionsWithImageViewController(viewModel: viewModel)
+        case .gdsInstructionsWithImageModally:
+            let viewModel = MockInstructionsWithImageViewModel(warningButtonViewModel: mockButtonViewModel,
+                                                               primaryButtonViewModel: mockButtonViewModel,
+                                                               secondaryButtonViewModel: mockSecondaryButtonViewModel,
+                                                               rightBarButtonTitle: "Close",
+                                                               screenView: {},
+                                                               dismissAction: {})
             return InstructionsWithImageViewController(viewModel: viewModel)
         case .gdsModalInfoView:
             let viewModel = MockModalInfoViewModel()

--- a/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/GDSInstructionsViewControllerTests.swift
@@ -141,11 +141,11 @@ extension GDSInstructionsViewController {
 
 struct MockButtonViewModel: ButtonViewModel {
     let title: GDSLocalisedString
-    let icon: String?
+    let icon: ButtonIconViewModel?
     let shouldLoadOnTap: Bool
     let action: () -> Void
     
-    init(title: GDSLocalisedString, icon: String? = nil, shouldLoadOnTap: Bool = false, action: @escaping () -> Void) {
+    init(title: GDSLocalisedString, icon: ButtonIconViewModel? = nil, shouldLoadOnTap: Bool = false, action: @escaping () -> Void) {
         self.title = title
         self.icon = icon
         self.shouldLoadOnTap = shouldLoadOnTap

--- a/GDSCommon-Demo/GDSCommon-DemoTests/InstructionsWithImageViewControllerTests.swift
+++ b/GDSCommon-Demo/GDSCommon-DemoTests/InstructionsWithImageViewControllerTests.swift
@@ -26,7 +26,7 @@ final class InstructionsWithImageViewControllerTests: XCTestCase {
                                                                                                    action: { self.didTapPrimaryButton = true }),
                                                        secondaryButtonViewModel: MockButtonViewModel(title: "Secondary Button",
                                                                                                      shouldLoadOnTap: false,
-                                                                                                     action: { self.didTapSecondaryButton = true }), 
+                                                                                                     action: { self.didTapSecondaryButton = true }),
                                                        rightBarButtonTitle: "close",
                                                        screenView: {
             self.screenDidAppear = true

--- a/Sources/GDSCommon/UI/SwiftUI/SharedViews/Buttons/ButtonView.swift
+++ b/Sources/GDSCommon/UI/SwiftUI/SharedViews/Buttons/ButtonView.swift
@@ -20,7 +20,7 @@ public struct ButtonView: View {
                         .padding(5)
                 } else {
                     if let icon = buttonViewModel.icon {
-                        Text("\(buttonViewModel.title.value)\u{00A0}\(Image(systemName: icon))")
+                        Text("\(buttonViewModel.title.value)\u{00A0}\(Image(systemName: icon.iconName))")
                     } else {
                         Text(buttonViewModel.title.value)
                     }
@@ -31,7 +31,7 @@ public struct ButtonView: View {
                 } else {
                     Text(buttonViewModel.title.value)
                     if let icon = buttonViewModel.icon {
-                        Image(systemName: icon)
+                        Image(systemName: icon.iconName)
                     }
                 }
             }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Buttons/ButtonIconViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Buttons/ButtonIconViewModel.swift
@@ -1,0 +1,8 @@
+public protocol ButtonIconViewModel {
+    var iconName: String { get }
+    var symbolPosition: SymbolPosition { get }
+}
+
+public struct ButtonIcon {
+    public static let arrowUpRight: String = "arrow.up.right"
+}

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Buttons/ButtonViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Buttons/ButtonViewModel.swift
@@ -6,12 +6,3 @@ public protocol ButtonViewModel {
     var shouldLoadOnTap: Bool { get }
     var action: () -> Void { get }
 }
-
-public protocol ButtonIconViewModel {
-    var iconName: String { get }
-    var symbolPosition: SymbolPosition { get }
-}
-
-public struct ButtonIcon {
-    public static let arrowUpRight: String = "arrow.up.right"
-}

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Buttons/ButtonViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Buttons/ButtonViewModel.swift
@@ -2,9 +2,14 @@ import UIKit
 
 public protocol ButtonViewModel {
     var title: GDSLocalisedString { get }
-    var icon: String? { get }
+    var icon: ButtonIconViewModel? { get }
     var shouldLoadOnTap: Bool { get }
     var action: () -> Void { get }
+}
+
+public protocol ButtonIconViewModel {
+    var iconName: String { get }
+    var symbolPosition: SymbolPosition { get }
 }
 
 public struct ButtonIcon {

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.xib
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Components/BulletView.xib
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -39,7 +38,7 @@
                 </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="rmW-0z-jEB" secondAttribute="bottom" id="68v-tq-e3I"/>
                 <constraint firstItem="rmW-0z-jEB" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="BYt-0k-L2c"/>
@@ -49,9 +48,4 @@
             <point key="canvasLocation" x="139" y="121"/>
         </view>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/GDSInstructions/GDSInstructionsViewController.swift
@@ -90,6 +90,12 @@ public class GDSInstructionsViewController: UIViewController {
                 secondaryButton.setTitle(buttonViewModel.title, for: .normal)
                 secondaryButton.accessibilityIdentifier = "instructions-secondary-button"
                 secondaryButton.isHidden = false
+                
+                if let icon = viewModel.secondaryButtonViewModel?.icon {
+                    secondaryButton.symbolPosition = icon.symbolPosition
+                    secondaryButton.icon = icon.iconName
+                }
+                
             } else {
                 secondaryButton.isHidden = true
             }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImage.xib
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImage.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,6 +14,7 @@
                 <outlet property="bodyLabel" destination="peh-mt-I2A" id="DgI-0C-5yp"/>
                 <outlet property="imageView" destination="DZG-TU-vNg" id="BO6-dt-gg8"/>
                 <outlet property="primaryButton" destination="exa-iY-8Ar" id="1Ym-zz-JCT"/>
+                <outlet property="secondaryButton" destination="myj-Dn-61A" id="URr-az-Mik"/>
                 <outlet property="titleLabel" destination="NRz-6E-ghN" id="as0-HL-1fL"/>
                 <outlet property="view" destination="iN0-l3-epB" id="LW6-8m-mNZ"/>
                 <outlet property="warningButton" destination="p4G-i5-7Mx" id="Nk7-LE-JZ0"/>
@@ -25,10 +26,10 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sTf-aB-pTa">
-                    <rect key="frame" x="0.0" y="59" width="393" height="694"/>
+                    <rect key="frame" x="0.0" y="59" width="393" height="640"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="HOE-Hu-h71">
-                            <rect key="frame" x="0.0" y="0.0" width="393" height="444.33333333333331"/>
+                            <rect key="frame" x="0.0" y="0.0" width="393" height="516.66666666666663"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="OuA-Zr-e7o">
                                     <rect key="frame" x="0.0" y="8" width="393" height="136"/>
@@ -51,14 +52,11 @@
                                     </subviews>
                                     <directionalEdgeInsets key="directionalLayoutMargins" top="0.0" leading="16" bottom="0.0" trailing="16"/>
                                 </stackView>
-                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="249" image="linkWithSafari" translatesAutoresizingMaskIntoConstraints="NO" id="DZG-TU-vNg">
-                                    <rect key="frame" x="0.0" y="160" width="393" height="226"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" secondItem="DZG-TU-vNg" secondAttribute="height" multiplier="393:226" id="NNM-dJ-YGg"/>
-                                    </constraints>
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="249" image="linkWithSafari" translatesAutoresizingMaskIntoConstraints="NO" id="DZG-TU-vNg">
+                                    <rect key="frame" x="0.0" y="159.99999999999997" width="393" height="298.33333333333326"/>
                                 </imageView>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="top" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="p4G-i5-7Mx" customClass="SecondaryButton" customModule="GDSCommon">
-                                    <rect key="frame" x="0.0" y="402" width="393" height="34.333333333333314"/>
+                                    <rect key="frame" x="0.0" y="474.33333333333337" width="393" height="34.333333333333314"/>
                                     <state key="normal" title="Button"/>
                                     <buttonConfiguration key="configuration" style="plain" title="Button">
                                         <color key="baseForegroundColor" name="AccentColor"/>
@@ -71,6 +69,8 @@
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="DZG-TU-vNg" secondAttribute="trailing" id="KET-4E-lBb"/>
                                 <constraint firstItem="DZG-TU-vNg" firstAttribute="leading" secondItem="HOE-Hu-h71" secondAttribute="leading" id="LZR-ZY-9yy"/>
+                                <constraint firstAttribute="trailing" secondItem="DZG-TU-vNg" secondAttribute="trailing" id="W6D-Oy-3VY"/>
+                                <constraint firstItem="DZG-TU-vNg" firstAttribute="leading" secondItem="HOE-Hu-h71" secondAttribute="leading" id="YKB-DB-vyO"/>
                             </constraints>
                             <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="0.0" bottom="8" trailing="0.0"/>
                         </stackView>
@@ -87,7 +87,7 @@
                     <viewLayoutGuide key="frameLayoutGuide" id="Ckc-50-jtt"/>
                 </scrollView>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="21" translatesAutoresizingMaskIntoConstraints="NO" id="KQw-4J-8PG">
-                    <rect key="frame" x="16" y="769" width="361" height="33"/>
+                    <rect key="frame" x="16" y="715" width="361" height="87"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="exa-iY-8Ar" customClass="RoundedButton" customModule="GDSCommon">
                             <rect key="frame" x="0.0" y="0.0" width="361" height="33"/>
@@ -96,6 +96,15 @@
                             <state key="normal" title="Start"/>
                             <connections>
                                 <action selector="primaryButtonAction:" destination="-1" eventType="touchUpInside" id="CT6-9E-aVE"/>
+                            </connections>
+                        </button>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="myj-Dn-61A" customClass="SecondaryButton" customModule="GDSCommon">
+                            <rect key="frame" x="0.0" y="54" width="361" height="33"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" title="Start"/>
+                            <connections>
+                                <action selector="secondaryButtonAction:" destination="-1" eventType="touchUpInside" id="apN-dW-OqQ"/>
                             </connections>
                         </button>
                     </subviews>
@@ -107,6 +116,7 @@
                 <constraint firstItem="KQw-4J-8PG" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="2h5-Pk-ap8"/>
                 <constraint firstItem="sTf-aB-pTa" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Ck1-WT-3UG"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="sTf-aB-pTa" secondAttribute="trailing" id="IjO-Tq-y35"/>
+                <constraint firstItem="DZG-TU-vNg" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" multiplier="0.35" id="Oiq-Yj-xob"/>
                 <constraint firstItem="sTf-aB-pTa" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="Yhu-mM-ZCh"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="KQw-4J-8PG" secondAttribute="trailing" constant="16" id="fio-zo-mfM"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="KQw-4J-8PG" secondAttribute="bottom" constant="16" id="lNq-zM-rFb"/>

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewController.swift
@@ -111,10 +111,10 @@ public final class InstructionsWithImageViewController: UIViewController {
                 
                 secondaryButton.setTitle(secondaryButtonViewModel.title,
                                          for: .normal)
-                secondaryButton.accessibilityIdentifier = "secondaryButton"
             } else {
                 secondaryButton.isHidden = true
             }
+            secondaryButton.accessibilityIdentifier = "secondaryButton"
         }
     }
     

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewController.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewController.swift
@@ -29,6 +29,18 @@ public final class InstructionsWithImageViewController: UIViewController {
         super.init(nibName: "InstructionsWithImage", bundle: .module)
     }
     
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: false)
+
+        if viewModel.rightBarButtonTitle != nil {
+            self.navigationItem.rightBarButtonItem = .init(title: viewModel.rightBarButtonTitle?.value,
+                                                           style: .done,
+                                                           target: self,
+                                                           action: #selector(dismissScreen))
+        }
+    }
+    
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
@@ -85,6 +97,27 @@ public final class InstructionsWithImageViewController: UIViewController {
         }
     }
     
+    /// secondaryButton button: ``SecondaryButton``. This is an optional property on the `viewModel`.
+    /// If it is `nil` on `viewModel` then the button is not displayed
+    @IBOutlet private var secondaryButton: SecondaryButton! {
+        didSet {
+            if let secondaryButtonViewModel = viewModel.secondaryButtonViewModel {
+                secondaryButton.isHidden = false
+                
+                if let icon = viewModel.secondaryButtonViewModel?.icon {
+                    secondaryButton.symbolPosition = icon.symbolPosition
+                    secondaryButton.icon = icon.iconName
+                }
+                
+                secondaryButton.setTitle(secondaryButtonViewModel.title,
+                                         for: .normal)
+                secondaryButton.accessibilityIdentifier = "secondaryButton"
+            } else {
+                secondaryButton.isHidden = true
+            }
+        }
+    }
+    
     @IBAction private func warningButtonAction(_ sender: Any) {
         if let buttonViewModel = viewModel.warningButtonViewModel {
             buttonViewModel.action()
@@ -93,5 +126,17 @@ public final class InstructionsWithImageViewController: UIViewController {
     
     @IBAction private func primaryButtonAction(_ sender: Any) {
         viewModel.primaryButtonViewModel.action()
+    }
+    
+    @IBAction private func secondaryButtonAction(_ sender: Any) {
+        if let buttonViewModel = viewModel.secondaryButtonViewModel {
+            buttonViewModel.action()
+        }
+    }
+    
+    @objc private func dismissScreen() {
+        self.dismiss(animated: true)
+        
+        viewModel.didDismiss()
     }
 }

--- a/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
+++ b/Sources/GDSCommon/UI/UIKit/SharedViews/Patterns/InstructionsWithImage/InstructionsWithImageViewModel.swift
@@ -17,6 +17,9 @@ public protocol InstructionsWithImageViewModel {
     var image: UIImage { get }
     var warningButtonViewModel: ButtonViewModel? { get }
     var primaryButtonViewModel: ButtonViewModel { get }
-    
+    var secondaryButtonViewModel: ButtonViewModel? { get }
+    var rightBarButtonTitle: GDSLocalisedString? { get }
+
     func didAppear()
+    func didDismiss()
 }

--- a/Tests/GDSCommonTests/ComponentTests/Mocks/MockButtonViewModel.swift
+++ b/Tests/GDSCommonTests/ComponentTests/Mocks/MockButtonViewModel.swift
@@ -2,11 +2,11 @@ import GDSCommon
 
 internal struct MockButtonViewModel: ButtonViewModel {
     let title: GDSLocalisedString
-    let icon: String?
+    let icon: ButtonIconViewModel?
     let shouldLoadOnTap: Bool
     let action: () -> Void
     
-    init(title: GDSLocalisedString, icon: String? = nil, shouldLoadOnTap: Bool = false, action: @escaping () -> Void) {
+    init(title: GDSLocalisedString, icon: ButtonIconViewModel? = nil, shouldLoadOnTap: Bool = false, action: @escaping () -> Void) {
         self.title = title
         self.icon = icon
         self.shouldLoadOnTap = shouldLoadOnTap


### PR DESCRIPTION
# feat: adding-optional-parameters-for-image-instructions

_Thank you for your contribution to the project._

feat: adding-optional-parameters-for-image-instructions

We have no way of adding an icon to the secondary button, on the Instructions View Controller. This PR is to enable that so we can add an icon when using that view from GDS Common.

This also adds the option to open the GDSInstructions view modally, and with an optional second button.

# Checklist

## Before raising your pull request:
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
